### PR TITLE
Add coggle.it to Diagram tools

### DIFF
--- a/tools/diagram.md
+++ b/tools/diagram.md
@@ -4,6 +4,7 @@
 * [Cacoo](https://cacoo.com) [free to $]
 * [gliffy](https://www.gliffy.com/products/online/) [free to $]
 * [sketchboard.io](https://sketchboard.io) [$]
+* [coggle](https://coggle.it) [free to $]
 
 
 


### PR DESCRIPTION
I've found Coggle to be really convenient as a freemium tool for brainstorming and creating mind maps. There are paid tiers, but they aren't really necessary to benefit from this web app. Unlike some of these other tools, it's unlimited in the public diagrams you can create.