### PR TITLE
Remove emotional statement about strict types

### DIFF
--- a/recap.md
+++ b/recap.md
@@ -20,7 +20,7 @@ and [JavaScript Object Explorer](https://sdras.github.io/object-explorer/). This
 * [Brave](https://brave.com/) becomes the most pleasant and safest way to browser the internet.
 * [PhantomJS is no longer maintained](https://www.infoq.com/news/2017/04/Phantomjs-future-uncertain), [Headless Chrome](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) and [Puppeteer](https://github.com/GoogleChrome/puppeteer) step in.
 * [Prettier](https://prettier.io/) comes from left field and becomes a staple for development.
-* A whole lot of developers adopt static type checking for mostly subjective reasons or band wagon emotions. Some sell out completely to [Typescript](https://github.com/Microsoft/TypeScript) and the Microsoft way of doing things while others take on a slower approach with [Flow](https://github.com/facebook/flow). One thing is for sure, most developers don't need types, they are simply complicating already complex problems and solutions. Like most things, most of this trend is subjective dogma not objective value.
+* developers coming from other programming languages or working in projects where type-safety brings benefits choose either from [Typescript](https://github.com/Microsoft/TypeScript) or [Flow](https://github.com/facebook/flow).
 * [Static site generators](https://www.staticgen.com/) & [API CMS tools aka Headless CMS's](https://en.wikipedia.org/wiki/Headless_CMS) are now on most developers radar.
 * Web components still lurking and wait for significant traction by developers that might never come to be.
 * JavaScript settled and [CSS erupt](http://michelebertoli.github.io/css-in-js/) and everyone will cry fatigue by this time next year.


### PR DESCRIPTION
Except assembler and brainfuck, all programming languages do have types, so that statement "developers don't need types" is wrong. 
It's true that there are developers that don't want type-safety, syntax-coloring, compile time quality checks and solely work with `ed`, but many others appreciate helpful IDE insights, preflight checks and as few runtime errors as possible. 
I suggest to keep it brief and professional instead of trying to shuffle in your personal and biased opinion.
(And no, I don't work for Microsoft)