### PR TITLE
Add React For Beginners back in

### DIFF
--- a/learning/react.md
+++ b/learning/react.md
@@ -11,6 +11,7 @@
 * [React 🎄](https://react.holiday/) [read]
 * [React Enlightenment](https://www.reactenlightenment.com/) [read]
 * [REACT JS TUTORIAL #1 - Reactjs Javascript Introduction & Workspace Setup](https://www.youtube.com/watch?v=MhkGQAoc7bc&t=6s) [watch]
+* [React For Beginners](https://ReactForBeginners.com) [watch][$]
 
 ##### Mastering React:
 


### PR DESCRIPTION
Looks like my course was taken out in January for some reason. Perhaps it was lost in reshuffling them?

https://github.com/FrontendMasters/front-end-handbook-2018/commit/98bdfdb84676d4d40fb79cda8d01f11cd2f0389c#diff-89906c61dd489e1df08ec292221c3a17