### PR TITLE
fix typo JSON summary

### DIFF
--- a/practice/tech-employed-by-fd.md
+++ b/practice/tech-employed-by-fd.md
@@ -105,7 +105,7 @@ Most relevant documentation:
 
 #### JavaScript Object Notation (aka JSON)
 
-> c It is the primary data format used for asynchronous browser/server communication (AJAJ), largely replacing XML (used by AJAX). Although originally derived from the JavaScript scripting language, JSON is a language-independent data format. Code for parsing and generating JSON data is readily available in many programming languages. The JSON format was originally specified by Douglas Crockford. It is currently described by two competing standards, RFC 7159 and ECMA-404. The ECMA standard is minimal, describing only the allowed grammar syntax, whereas the RFC also provides some semantic and security considerations. The official Internet media type for JSON is application/json. The JSON filename extension is .json.
+> It is the primary data format used for asynchronous browser/server communication (AJAJ), largely replacing XML (used by AJAX). Although originally derived from the JavaScript scripting language, JSON is a language-independent data format. Code for parsing and generating JSON data is readily available in many programming languages. The JSON format was originally specified by Douglas Crockford. It is currently described by two competing standards, RFC 7159 and ECMA-404. The ECMA standard is minimal, describing only the allowed grammar syntax, whereas the RFC also provides some semantic and security considerations. The official Internet media type for JSON is application/json. The JSON filename extension is .json.
 
 ><cite>&#8212; [Wikipedia](https://en.wikipedia.org/wiki/JSON)</cite>
 


### PR DESCRIPTION
Removed "c" from the start of the JSON summary on the Tech Employed section