### PR TITLE
Update Remote In Tech companies

### DIFF
--- a/practice/jobboards.md
+++ b/practice/jobboards.md
@@ -17,7 +17,7 @@ A plethora of technical job listing outlets exist. The narrowed list below are c
 
 ###### NOTES:
 
-Looking for a remote front-end Job, check out these [Remote-friendly companies](https://github.com/jessicard/remote-jobs)
+Looking for a remote front-end Job, check out these [Remote-friendly companies](https://remoteintech.company/)
 
 
 


### PR DESCRIPTION
Thanks for including the site in the book!

The project grew up a good while back and moved from `https://github.com/jessicard/remote-jobs/` to `https://github.com/remoteintech/remote-jobs`

It now has a site - https://remoteintech.company 😃 